### PR TITLE
Dark mode capable software feature icons

### DIFF
--- a/Images/close.svg
+++ b/Images/close.svg
@@ -1,1 +1,35 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24"><path d="m256-200-56-56 224-224-224-224 56-56 224 224 224-224 56 56-224 224 224 224-56 56-224-224-224 224Z"/></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="24px"
+   viewBox="0 -960 960 960"
+   width="24px"
+   fill="#e3e3e3"
+   version="1.1"
+   id="svg1"
+   xml:space="preserve"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+     id="defs1"><linearGradient
+       id="swatch3"><stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3" /></linearGradient><linearGradient
+       id="swatch2"><stop
+         style="stop-color:#4dcbdc;stop-opacity:1;"
+         offset="0"
+         id="stop2" /></linearGradient><linearGradient
+       id="swatch1"><stop
+         style="stop-color:#4dcbdc;stop-opacity:1;"
+         offset="0"
+         id="stop1" /></linearGradient><linearGradient
+       xlink:href="#swatch3"
+       id="linearGradient3"
+       x1="200"
+       y1="-480"
+       x2="760"
+       y2="-480"
+       gradientUnits="userSpaceOnUse" /></defs><path
+     d="m 256,-200 -56,-56 224,-224 -224,-224 56,-56 224,224 224,-224 56,56 -224,224 224,224 -56,56 -224,-224 z"
+     id="path1-4"
+     style="fill:url(#swatch2);stroke:url(#linearGradient3);stroke-width:30.2362204;stroke-dasharray:none" /></svg>

--- a/Images/download.svg
+++ b/Images/download.svg
@@ -1,150 +1,47 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   width="1024"
-   height="1024"
-   viewBox="0 0 1024 1024"
+   height="24"
+   viewBox="0 -960 960 960"
+   width="24"
    version="1.1"
+   id="svg1"
    xml:space="preserve"
-   style="clip-rule:evenodd;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2"
-   id="svg7"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"><defs
-   id="defs7"><linearGradient
-     id="swatch16"><stop
-       style="stop-color:#ffffff;stop-opacity:1;"
-       offset="0"
-       id="stop16" /></linearGradient><linearGradient
-     id="swatch15"><stop
-       style="stop-color:#0060c7;stop-opacity:1;"
-       offset="0"
-       id="stop15" /></linearGradient><linearGradient
-     id="swatch14"><stop
-       style="stop-color:#b4ce00;stop-opacity:1;"
-       offset="0"
-       id="stop14" /></linearGradient><linearGradient
-     id="swatch13"><stop
-       style="stop-color:#004697;stop-opacity:1;"
-       offset="0"
-       id="stop13" /></linearGradient><linearGradient
-     id="swatch12"><stop
-       style="stop-color:#00c1d6;stop-opacity:1;"
-       offset="0"
-       id="stop12" /></linearGradient><linearGradient
-     id="swatch11"><stop
-       style="stop-color:#0382e2;stop-opacity:1;"
-       offset="0"
-       id="stop11" /></linearGradient><style
-     id="style1">
-      .cls-1 {
-        fill: #0382e2;
-      }
-
-      .cls-1, .cls-2, .cls-3, .cls-4, .cls-5, .cls-6 {
-        stroke-width: 0px;
-      }
-
-      .cls-2 {
-        fill: #00c1d6;
-      }
-
-      .cls-3 {
-        fill: #b4ce00;
-      }
-
-      .cls-4 {
-        fill: #fff;
-      }
-
-      .cls-5 {
-        fill: #0060c7;
-      }
-
-      .cls-6 {
-        fill: #004697;
-      }
-    </style><style
-     id="style1-9">
-      .cls-1 {
-        fill: #0382e2;
-      }
-
-      .cls-1, .cls-2, .cls-3, .cls-4, .cls-5, .cls-6 {
-        stroke-width: 0px;
-      }
-
-      .cls-2 {
-        fill: #00c1d6;
-      }
-
-      .cls-3 {
-        fill: #b4ce00;
-      }
-
-      .cls-4 {
-        fill: #fff;
-      }
-
-      .cls-5 {
-        fill: #0060c7;
-      }
-
-      .cls-6 {
-        fill: #004697;
-      }
-    </style><style
-     id="style1-7">
-      .cls-1 {
-        fill: #fff;
-      }
-
-      .cls-1, .cls-2 {
-        stroke-width: 0px;
-      }
-
-      .cls-2 {
-        fill: #004697;
-      }
-    </style><linearGradient
-     xlink:href="#swatch13"
-     id="linearGradient1"
-     gradientUnits="userSpaceOnUse"
-     x1="132"
-     y1="512"
-     x2="892"
-     y2="512" /></defs>
-    
-    <g
-   id="g12"
-   clip-path="none"
-   style="clip-rule:evenodd;display:inline;fill-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2"><path
-     id="ellipse1"
-     clip-path="none"
-     style="clip-rule:evenodd;fill:url(#swatch11);fill-rule:evenodd;stroke-width:11.3386;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:2"
-     d="M 512,62 A 450,450 0 0 0 62,512 450,450 0 0 0 512,962 450,450 0 0 0 962,512 450,450 0 0 0 512,62 Z" /><path
-     id="ellipse2"
-     clip-path="none"
-     style="clip-rule:evenodd;fill:url(#swatch12);fill-rule:evenodd;stroke-width:17.6384;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:2"
-     d="M 959.40039,463.69727 A 1220.5096,449.45505 0 0 0 489.45898,818.11719 1220.5096,449.45505 0 0 0 552.06055,960.21289 450,450 0 0 0 962,512 450,450 0 0 0 959.40039,463.69727 Z" /><path
-     id="ellipse8"
-     clip-path="none"
-     style="clip-rule:evenodd;fill:url(#swatch14);fill-rule:evenodd;stroke-width:14.1512;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:2"
-     d="M 90.439453,669.43945 A 450,450 0 0 0 512,962 450,450 0 0 0 667.80859,934.16602 598.13824,328.4375 0 0 0 90.439453,669.43945 Z" /><path
-     id="ellipse9"
-     clip-path="none"
-     style="display:inline;fill:url(#swatch15);stroke-width:10.961;stroke-linecap:round;stroke-linejoin:round"
-     d="M 512,62 A 450,450 0 0 0 62,512 450,450 0 0 0 67.15625,579.92773 1044.7284,755.44653 0 0 0 709.94141,107.87305 450,450 0 0 0 512,62 Z" /><path
-     id="ellipse10"
-     clip-path="none"
-     style="fill:url(#swatch13);stroke-width:11.3386;stroke-linecap:round;stroke-linejoin:round"
-     d="M 442.28906,67.431641 A 450,450 0 0 0 63.238281,478.62695 1069.0244,912.20465 0 0 0 442.28906,67.431641 Z" /><path
-     id="circle12"
-     clip-path="none"
-     style="clip-rule:evenodd;display:inline;fill:url(#linearGradient1);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.43092;stroke-linejoin:round;stroke-miterlimit:2"
-     d="M 512,132 A 380,380 0 0 0 132,512 380,380 0 0 0 512,892 380,380 0 0 0 892,512 380,380 0 0 0 512,132 Z"><desc
-       id="desc10">This is the background behind the text</desc></path></g>
-<g
-   id="layer1"><path
-     d="m 307.02897,757.01118 v -49.00223 h 409.94207 v 49.00223 z M 512,659.00671 332.65035,438.49664 H 435.13587 V 266.98881 h 153.72827 v 171.50783 h 102.48551 z"
-     id="path1-9"
-     style="clip-rule:evenodd;fill:#ffffff;fill-rule:evenodd;stroke-width:0.626375;stroke-linejoin:round;stroke-miterlimit:2" /></g></svg>
+     id="defs1"><linearGradient
+       id="swatch4"><stop
+         style="stop-color:#a1a1a5;stop-opacity:1;"
+         offset="0"
+         id="stop4" /></linearGradient><linearGradient
+       id="swatch3"><stop
+         style="stop-color:#e3e3e3;stop-opacity:1;"
+         offset="0"
+         id="stop3" /></linearGradient><linearGradient
+       id="swatch2"><stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop2" /></linearGradient><linearGradient
+       id="swatch1"><stop
+         style="stop-color:#4dcbdc;stop-opacity:1;"
+         offset="0"
+         id="stop1" /></linearGradient><linearGradient
+       xlink:href="#swatch1"
+       id="linearGradient3"
+       x1="160"
+       y1="-480"
+       x2="800"
+       y2="-480"
+       gradientUnits="userSpaceOnUse" /><linearGradient
+       xlink:href="#swatch2"
+       id="linearGradient4"
+       x1="160"
+       y1="-480"
+       x2="800"
+       y2="-480"
+       gradientUnits="userSpaceOnUse" /></defs><g
+     style="fill:url(#linearGradient3);stroke:url(#linearGradient4);stroke-width:30.2362204;stroke-dasharray:none"
+     id="g2"><path
+       d="m 160,-80 v -80 h 640 v 80 z M 480,-240 200,-600 h 160 v -280 h 240 v 280 h 160 z"
+       id="path1-9"
+       style="fill:url(#linearGradient3);stroke:url(#linearGradient4);stroke-width:30.2362204;stroke-dasharray:none" /></g></svg>

--- a/Images/refresh.svg
+++ b/Images/refresh.svg
@@ -1,1 +1,49 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24"><path d="M480-160q-134 0-227-93t-93-227q0-134 93-227t227-93q69 0 132 28.5T720-690v-110h80v280H520v-80h168q-32-56-87.5-88T480-720q-100 0-170 70t-70 170q0 100 70 170t170 70q77 0 139-44t87-116h84q-28 106-114 173t-196 67Z"/></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="24px"
+   viewBox="0 -960 960 960"
+   width="24px"
+   fill="#e3e3e3"
+   version="1.1"
+   id="svg1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1">
+    <linearGradient
+       id="swatch2">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop2" />
+    </linearGradient>
+    <linearGradient
+       id="swatch1">
+      <stop
+         style="stop-color:#4dcbdc;stop-opacity:1;"
+         offset="0"
+         id="stop1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#swatch1"
+       id="linearGradient1"
+       x1="160"
+       y1="-480"
+       x2="800"
+       y2="-480"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#swatch2"
+       id="linearGradient2"
+       x1="160"
+       y1="-480"
+       x2="800"
+       y2="-480"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <path
+     d="M480-160q-134 0-227-93t-93-227q0-134 93-227t227-93q69 0 132 28.5T720-690v-110h80v280H520v-80h168q-32-56-87.5-88T480-720q-100 0-170 70t-70 170q0 100 70 170t170 70q77 0 139-44t87-116h84q-28 106-114 173t-196 67Z"
+     id="path1"
+     style="fill:url(#linearGradient1);stroke:url(#linearGradient2);stroke-width:30.2362204;stroke-dasharray:none" />
+</svg>

--- a/Images/tools.svg
+++ b/Images/tools.svg
@@ -1,1 +1,48 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24"><path d="M756-120 537-339l84-84 219 219-84 84Zm-552 0-84-84 276-276-68-68-28 28-51-51v82l-28 28-121-121 28-28h82l-50-50 142-142q20-20 43-29t47-9q24 0 47 9t43 29l-92 92 50 50-28 28 68 68 90-90q-4-11-6.5-23t-2.5-24q0-59 40.5-99.5T701-841q15 0 28.5 3t27.5 9l-99 99 72 72 99-99q7 14 9.5 27.5T841-701q0 59-40.5 99.5T701-561q-12 0-24-2t-23-7L204-120Z"/></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="24"
+   viewBox="0 -960 960 960"
+   width="24"
+   version="1.1"
+   id="svg1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1">
+    <linearGradient
+       id="swatch2">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop2" />
+    </linearGradient>
+    <linearGradient
+       id="swatch1">
+      <stop
+         style="stop-color:#4dcbdc;stop-opacity:1;"
+         offset="0"
+         id="stop1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#swatch1"
+       id="linearGradient1"
+       x1="100"
+       y1="-480.5"
+       x2="841"
+       y2="-480.5"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#swatch2"
+       id="linearGradient2"
+       x1="100"
+       y1="-480.5"
+       x2="841"
+       y2="-480.5"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <path
+     d="M756-120 537-339l84-84 219 219-84 84Zm-552 0-84-84 276-276-68-68-28 28-51-51v82l-28 28-121-121 28-28h82l-50-50 142-142q20-20 43-29t47-9q24 0 47 9t43 29l-92 92 50 50-28 28 68 68 90-90q-4-11-6.5-23t-2.5-24q0-59 40.5-99.5T701-841q15 0 28.5 3t27.5 9l-99 99 72 72 99-99q7 14 9.5 27.5T841-701q0 59-40.5 99.5T701-561q-12 0-24-2t-23-7L204-120Z"
+     id="path1"
+     style="stroke-width:30.2362204;stroke-dasharray:none;fill:url(#linearGradient1);stroke:url(#linearGradient2)" />
+</svg>


### PR DESCRIPTION
I noticed some of the QViewer software feature icons are hard to see in dark mode. I have systematically been converting the icons to a standard two tone colour system so that they work in both dark and light mode. This PR includes the four remaining icons for QViewer that needed this treatment.

I also switched the QViewer "downloader" to use this "software feature" icon standard instead of the riverscapes "tools" style with the circular border. This is a loose standard that @weblorin and I came up with.... Keep the icons with a border for tools and websites. Keep the simpler two tone icons for software (where they might appear smaller on menus etc and can have a larger icon size if we omit the border).