### PR TITLE
fix: RemoteProject missing has_bounds_layer / bounds_path (#246)

### DIFF
--- a/src/classes/remote_project.py
+++ b/src/classes/remote_project.py
@@ -58,6 +58,16 @@ class RemoteProject:
         bbox = self.bounds.get("bbox")
         return bool(bbox and len(bbox) >= 4)
 
+    @property
+    def has_bounds_layer(self) -> bool:
+        """Remote projects have no local bounds GeoJSON file"""
+        return False
+
+    @property
+    def bounds_path(self) -> None:
+        """Remote projects have no local bounds GeoJSON file path"""
+        return None
+
     def _extract_meta(self, meta_list: list[dict]) -> dict:
         meta = {}
         if meta_list is None:

--- a/test/test_remote_project.py
+++ b/test/test_remote_project.py
@@ -1,0 +1,63 @@
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+from src.classes.remote_project import RemoteProject
+
+# Add project root to path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Create dummy modules to satisfy imports
+import types
+
+
+def mock_module(name, attrs=None):
+    m = types.ModuleType(name)
+    if attrs:
+        for k, v in attrs.items():
+            setattr(m, k, v)
+    sys.modules[name] = m
+    return m
+
+
+mock_module("qgis")
+mock_module("qgis.core", {"Qgis": MagicMock(), "QgsMessageLog": MagicMock()})
+mock_module("qgis.PyQt")
+mock_module("qgis.PyQt.QtGui", {"QIcon": MagicMock(), "QStandardItem": MagicMock()})
+mock_module("qgis.PyQt.QtCore")
+
+# Mock our own package structure
+# We don't want to mock 'src.classes.remote_project' because we want to load it
+mock_module("src.compat", {"USER_ROLE": 1000})
+mock_module("src.icon_utils", {"qrave_icon": MagicMock()})
+mock_module("src.classes.qrave_map_layer", {"ProjectTreeData": MagicMock(), "QRaveMapLayer": MagicMock(), "QRaveTreeTypes": MagicMock()})
+mock_module("src.classes.settings", {"CONSTANTS": {"DE_API_URL": "http://test"}, "Settings": MagicMock()})
+
+
+class TestRemoteProject(unittest.TestCase):
+    def setUp(self):
+        self.gql_data = {"project": {"id": "test-id", "name": "Test Project", "bounds": {"bbox": [0, 0, 1, 1]}}}
+        self.project = RemoteProject(self.gql_data)
+
+    def test_has_bounds_layer(self):
+        """Test that has_bounds_layer exists and returns False"""
+        self.assertTrue(hasattr(self.project, "has_bounds_layer"))
+        self.assertFalse(self.project.has_bounds_layer)
+
+    def test_bounds_path(self):
+        """Test that bounds_path exists and returns None"""
+        self.assertTrue(hasattr(self.project, "bounds_path"))
+        self.assertIsNone(self.project.bounds_path)
+
+    def test_has_bounds(self):
+        """Verify existing has_bounds still works"""
+        self.assertTrue(self.project.has_bounds)
+
+        # Test with no bounds
+        no_bounds_proj = RemoteProject({"project": {"id": "no-bounds"}})
+        self.assertFalse(no_bounds_proj.has_bounds)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Right-clicking a remote project node raised:
  AttributeError: 'RemoteProject' object has no attribute 'has_bounds_layer'

The has_bounds_layer property (and bounds_path) were added to RSProject in #233 (Add Project Bounds to Map). dock_widget.py accesses these duck-typed on any project object, but RemoteProject was never updated.

Fix: add has_bounds_layer -> False and bounds_path -> None properties to RemoteProject. Remote projects are streamed from the Data Exchange and have no local GeoJSON bounds file, so False/None are the correct values.

Also adds test/test_remote_project.py covering the new properties and the existing has_bounds property.